### PR TITLE
Add optional argument to k's rm command

### DIFF
--- a/extensions/k.ksh
+++ b/extensions/k.ksh
@@ -22,7 +22,7 @@ k() {
 		K=~/.k
 		case $1 in
 		clean)	sort -u $K -o ${K};;
-		rm)	sed -i -E "\#^${PWD}\$#d" ${K};;
+		rm)	sed -i -E "\#^${2:-${PWD}}\$#d" ${K};;
 		ls)	cat ${K};;
 		*)	cd "$(grep -e "$1" ${K} | head -n 1)";;
 		esac

--- a/extensions/k.ksh
+++ b/extensions/k.ksh
@@ -21,7 +21,7 @@ k() {
 	else
 		K=~/.k
 		case $1 in
-		clean)	sort $K | uniq > ${K}.tmp && mv ${K}.tmp ${K};;
+		clean)	sort -u $K -o ${K};;
 		rm)	sed -i -E "\#^${PWD}\$#d" ${K};;
 		ls)	cat ${K};;
 		*)	cd "$(grep -e "$1" ${K} | head -n 1)";;


### PR DESCRIPTION
Hi,

Here's a diff to add support for optional arguments to `k` extension's `rm` command.
Sometimes it's more convenient (for me) to remove a path from `k` without entering it. the following diff allows
an optional argument to `rm` command. Here's an example:

```sh
$ k ls
/tmp
/usr/ports
/home/bijan
$ k rm /tmp
$ k ls
/usr/ports
/home/bijan
$ k ports
$ pwd
/usr/ports
$ k rm
$ k ls
/home/bijan
```

Also I simplified the `clean` command by removing the pipes and using `sort`'s `-u` and `-o` arguments remove the duplicated records and storing the sorted result back to `k`'s database.