### PR TITLE
added X11R6 and local manpage dirs

### DIFF
--- a/completions/man.ksh
+++ b/completions/man.ksh
@@ -1,9 +1,8 @@
 #: | man | man pages |
 MAN_CACHE=$LOAD_PATH/cache/man
 if [ ! -f $MAN_CACHE ]; then
-	MANPATH=/usr/share/man man -k Nm~. | cut -d\( -f1 | tr -d , | \
-		sort | \
-		uniq > $MAN_CACHE
+	mkdir -p `dirname ${MAN_CACHE}`
+	ls /usr/{share,X11R6,local}/man/man[1-9] | sort -u > $MAN_CACHE
 fi
 
 set -A complete_man_1 -- $(cat $MAN_CACHE)


### PR DESCRIPTION
Hi,

Here's a diff to include `X11R6` and `local` directories to list of manpages. I found it a little more faster and a little more cleaner to use `ls` instead of current chain of commands.

Also It is possible considering reading [man.conf](https://man.openbsd.org/man.conf) if available, beforeusing  of hard-coding the list of man-page directories, but maybe it should wait for another diff

Cheers,