### PR TITLE
Update git commands and aliases to git auto-completion

### DIFF
--- a/completions/git.ksh
+++ b/completions/git.ksh
@@ -1,18 +1,4 @@
 #: | git | add, fetch... |
 set -A complete_git_1 -- \
-	add am archive \
-	bisect branch bundle \
-	checkout cherry-pick citool clean clone commit config \
-	describe diff \
-	fetch format-patch \
-	gc grep gui \
-	init \
-	log \
-	merge mv \
-	notes \
-	pull push \
-	range-diff rebase reset restore revert rm \
-	shortlog show sparse-checkout stash status submodule switch \
-	tag \
-	worktree \
+	`man -cT man git | grep -o 'git-[a-z-]*' | sort -u | cut -d '-' -f2-` \
 	`git config --get-regexp ^alias\. | awk -F '[\. ]' '{ print $2 }'`

--- a/completions/git.ksh
+++ b/completions/git.ksh
@@ -14,4 +14,5 @@ set -A complete_git_1 -- \
 	range-diff rebase reset restore revert rm \
 	shortlog show sparse-checkout stash status submodule switch \
 	tag \
-	worktree
+	worktree \
+	`git config --get-regexp ^alias\. | awk -F '[\. ]' '{ print $2 }'`


### PR DESCRIPTION
Hi,

This simply allows to populate the list of git internal commands and global defined aliases (located in `~/.gitconfig`) to be included in git auto-completion. List of git-commands are extracted from [git(1) manual page][1] which hopefully should be in sync with the latest release of git in ports.

Hope it helps,
Cheers

[1]: https://man.openbsd.org/ports-current/git