### PR TITLE
List git commands simply and portably

### DIFF
--- a/completions/git.ksh
+++ b/completions/git.ksh
@@ -1,4 +1,4 @@
 #: | git | add, fetch... |
 set -A complete_git_1 -- \
-	$(man -cT man git | grep -o 'git-[a-z-]*' | sort -u | cut -d '-' -f2-) \
+	$(git --list-cmds=main) \
 	$(git config --get-regexp ^alias\. | awk -F '[\. ]' '{ print $2 }')

--- a/completions/git.org
+++ b/completions/git.org
@@ -8,6 +8,6 @@ The completions for level one are dynamically created using the following
 commands:
 
 #+begin_src ksh
-	$(man -cT man git | grep -o 'git-[a-z-]*' | sort -u | cut -d '-' -f2-) \
+	$(git --list-cmds=main) \
 	$(git config --get-regexp ^alias\. | awk -F '[\. ]' '{ print $2 }')
 #+end_src


### PR DESCRIPTION
Not sure if this is a goal of the project but this changeset means my git completions work on systems other than OpenBSD as well. Half of the boxes I work on are FreeBSD and the flags for `man` are a little different.