### PR TITLE
Fix and improve man(1) completion

### DIFF
--- a/completions/man.ksh
+++ b/completions/man.ksh
@@ -2,8 +2,10 @@
 MAN_CACHE=$LOAD_PATH/cache/man
 if [ ! -f $MAN_CACHE ]; then
 	mkdir -p $(dirname ${MAN_CACHE})
-	ls /usr/{share,X11R6,local}/man/man[1-9] | sort -u > $MAN_CACHE
+	for i in /usr{,/X11R6,/local}{,/share}/man/{,cat,man}[1-9lnp]{,f,p}
+	do
+		test -d $i && ls $i
+	done | rev | cut -d. -f2- | rev | sort -u > $MAN_CACHE
 fi
 
-set -A complete_man_1 -- $(cat $MAN_CACHE)
-
+set -A complete_man -- $(cat $MAN_CACHE)

--- a/completions/man.org
+++ b/completions/man.org
@@ -5,7 +5,10 @@
 Completions for man pages are found via:
 
 #+begin_src shell
-ls /usr/{share,X11R6,local}/man/man[1-9] | sort -u > $MAN_CACHE
+for i in /usr{,/X11R6,/local}{,/share}/man/{,cat,man}[1-9lnp]{,f,p}
+do
+	test -d $i && ls $i
+done | rev | cut -d. -f2- | rev | sort -u > $MAN_CACHE
 #+end_src
 
 Currently the cache is never re-created. Operating without a cache causes


### PR DESCRIPTION
Fixes several issues in the current `man(1)` completion:

- _section_ numbers are not stripped off
- _Perl Programmers Reference Guide_ (`3p`) section is ignored
- manual page name can only be completed as the 1st argument

While there, add `cat*` manual page hierarchies for _graphiz_